### PR TITLE
List many objects

### DIFF
--- a/test/tests3.jl
+++ b/test/tests3.jl
@@ -59,6 +59,14 @@ function test_bucket_ops(env)
     #info("Sleep for 10 secs ....")
     #sleep(10)
 
+    info("list objects")
+    (bkt,objs) = S3.list_objects(env, bkt, "fi")
+    @test collect(objs) == ["file1", "file2", "file3"]
+
+    info("list objects with details")
+    (bkt,objs) = S3.list_objects(env, bkt, "fi", details=true)
+    @test [o.key for o in objs] == ["file1", "file2", "file3"]
+
     info("delete file 1")
     resp = S3.del_object(env, bkt, "file1")
     check_resp(resp, String)


### PR DESCRIPTION
Depends on #107 and #108.

Changes:

* `list_objects` can return all objects in a bucket. Not just the first 1000.
* `list_objects` returns a Channel (which can be used as an iterator) instead of an Array. New lists are only requested as needed, so it's possible for the caller to abort.
* `list_objects` can return details of the listing, such as timestamp of last modified and etag, if the keyword argument details is set to true.